### PR TITLE
Create python docker image with sonar-scanner-cli

### DIFF
--- a/sonar-scanner/Dockerfile
+++ b/sonar-scanner/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.7
+
+RUN pip --no-cache-dir install \
+    pipenv \
+    pytest \
+    boto3
+
+# Install sonar-scanner which is used to perform code analysis thorugh SonarQube
+# TODO: download this binary from AWS resources bucket once the proxy is in place
+ADD https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.0.0.1744-linux.zip ./sonarscanner.zip
+RUN unzip sonarscanner.zip && \
+    rm sonarscanner.zip && \
+    mv sonar-scanner-4.0.0.1744-linux /usr/lib/sonar-scanner && \
+    ln -s /usr/lib/sonar-scanner/bin/sonar-scanner /usr/local/bin/sonar-scanner

--- a/sonar-scanner/README.md
+++ b/sonar-scanner/README.md
@@ -1,0 +1,32 @@
+# ci-python-sonar-build-3.7
+
+Python build image with sonar-scanner for analysing code through Sonar used for Concourse builds
+
+# Building the image
+Run the following command in this folder to build a new image:
+
+```
+docker build -t i-python-sonar-build-3.7 -f ./Dockerfile ..
+```
+
+This will use the Dockerfile within the current folder but set the context to the parent folder `..` to be able to include the resources from the parent folder to avoid needing to duplicate resources.
+
+# Running a container
+This will start a container using the previously built image and keep it open in interactive mode. To exit the container use `CTRL + C`.
+
+```
+docker run -it --rm i-python-sonar-build-3.7
+```
+
+# Deleting the image
+View all images to find the image ID
+
+```
+docker images
+```
+
+Delete the image using the image ID.
+
+```
+docker rm [ID]
+```


### PR DESCRIPTION
Creating a python docker image that contains sonar-scanner-cli.
The image will be used to run unit-tests and sonarqube

Resolves LFA-1929